### PR TITLE
Requested changes in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,40 @@
+# Martini Build Pipeline with AWS CodePipeline
 
-# Martini Build Pipeline
+This Martini Build Pipeline, utilizing AWS CodePipeline, provides two distinct build processes designed for flexibility and control over the deployment of Martini Server Runtime and its packages.
 
-This Martini Build Pipeline utilizes AWS CodePipeline. The repository includes two buildspec files for different build processes, such as building Docker images for the Martini runtime and uploading Martini packages. 
+### Build Options:
+1. **`martini-build-image.yaml`**
+This buildspec builds a Docker image that bundles the Martini Server Runtime with your Martini Packages, allowing you to manage both the runtime version and the packages within a single deployment. This approach ensures that you have full control over the deployment environment, making it ideal for scenarios where both runtime and package versions need to be tightly controlled.
 
-If you need to migrate from CodeCommit to another Git provider such as GitHub, follow this guide: [How to migrate your AWS CodeCommit repository to another Git provider](https://aws.amazon.com/blogs/devops/how-to-migrate-your-aws-codecommit-repository-to-another-git-provider/).
+2. **`martini-upload-package.yaml`**
+This buildspec focuses on deploying your Martini packages to an existing Martini Server Runtime instance. This method requires deploying only the packages, keeping the runtime instance unchanged, which is a streamlined option for environments where the runtime remains consistent but packages need frequent updates. 
 
+If you need to migrate from AWS CodeCommit to another Git provider such as GitHub, follow this guide: [How to migrate your AWS CodeCommit repository to another Git provider](https://aws.amazon.com/blogs/devops/how-to-migrate-your-aws-codecommit-repository-to-another-git-provider/).
 
-## Buildspec Files
-
-- **`martini-build-image.yaml`**: Responsible for building and pushing Docker images for the Martini runtime to AWS ECR.
-- **`martini-upload-package.yaml`**: Handles the zipping and uploading of Martini packages to the appropriate API endpoint.
-
-## Getting Started
-
-### Step 1: Choose the Appropriate Buildspec
-
-Determine which buildspec file suits your project's requirements, and ensure it is placed in the root directory of your repository.
-
-### Step 2: Update Environment Variables
-
-Make sure sensitive information like tokens, credentials, and URLs are securely managed by passing them as environment variables during the build process. These should be set in your local environment or CI/CD pipeline configuration.
-
-The necessary variables are stored in AWS Parameter Store, and the buildspec files retrieve them during the pre-build stage.
-
-### Step 3: Execute the Build
-
-Depending on your configuration, you can use the pipeline on its own or extend your own pipeline. To extend your pipeline, you can trigger the pipeline using the AWS CLI:
-
-```bash
-aws codepipeline start-pipeline-execution --name pipeline-name
-```
 
 ## Environment Variables
 
-The following environment variables are required for configuring this build process. These variables should be passed as environment variables when running the scripts or configuring your CI/CD pipeline:
+The variables listed below are used in the buildspec when configuring your CI/CD pipeline or running your pipeline. These are environment variables set in AWS Parameter Store for secure storage and easy retrieval during pipeline execution. This ensures that sensitive information, such as credentials and configuration settings, is protected and dynamically accessible.
 
 | **Variable Name**             | **Required** | **Description**                                                                                                         |
 |-------------------------------|--------------|-------------------------------------------------------------------------------------------------------------------------|
-| `MARTINI_VERSION`             | Yes          | The version of the Martini runtime to be used when building the Docker image.                                           |
-| `AWS_REGION`                  | Yes          | The AWS region where your ECR repository is located.                                                                   |
-| `AWS_ACCOUNT_ID`              | Yes          | The AWS account ID where the ECR repository is hosted.                                                                 |
-| `ECR_REPO_NAME`               | Yes          | The name of the ECR repository where the Docker image will be pushed.                                                  |
+| `MARTINI_VERSION`             | Yes          |The version of the Martini runtime to be used when building the Docker image. If not provided (null), it defaults to LATEST, but also supports explicit values of LATEST.                                           |
+| `AWS_REGION`                  | Yes          | The AWS region where your ECR repository is located.                                                                    |
+| `AWS_ACCOUNT_ID`              | Yes          | The AWS account ID where the ECR repository is hosted.                                                                  |
+| `ECR_REPO_NAME`               | Yes          | The name of the ECR repository where the Docker image will be pushed.                                                   |
 | `BASE_URL`                    | Yes          | The base URL for the API endpoint where packages will be uploaded and requests are made.                                |
 | `MARTINI_USER_NAME`           | Yes          | The username for authentication with the Martini API.                                                                   |
 | `MARTINI_USER_PASSWORD`       | Yes          | The password for authentication with the Martini API.                                                                   |
 | `${PARAMETER_NAME}`           | Yes          | The parameter store parameter name that is being used to fetch environment variables.                                   |
 
-## Input Descriptions
+## Running the Pipeline
 
-- **`DOCKER_IMAGE_NAME`**:  
-  - Defines the Docker image name and tag in the format `repository:tag` used for building and tagging the image.  
+By default, a pipeline starts automatically when it is created and any time a change is made in it's source repository. However, you might want to rerun the most recent revision through the pipeline a second time. You can use the CodePipeline console or the AWS CLI and start-pipeline-execution command to manually rerun the most recent revision through your pipeline.
 
-- **`MARTINI_VERSION`**:  
-  - Specifies the version of the Martini runtime included in the Docker image. It's passed as a build argument during the Docker build process.  
+To start the pipeline execution, use the following command:
 
-- **`BASE_URL`**:  
-  - The remote Martini Runtime Server’s base URL, used for uploading packages.  
+```bash
+aws codepipeline start-pipeline-execution --name pipeline-name
+```
 
-- **`MARTINI_USER_NAME`** and **`MARTINI_USER_PASSWORD`**:  
-  - Credentials needed to authenticate with the Martini API, essential for obtaining OAuth tokens and interacting with the API for package uploads.  
-
-- **`${PARAMETER_NAME}`**:  
-  - Refers to the name of the parameter in AWS SSM Parameter Store used to fetch environment variables like `MARTINI_VERSION`, `AWS_REGION`, `AWS_ACCOUNT_ID`, and `ECR_REPO_NAME`.  
+You can also use this pipeline as an extension of your pipeline and this can be achieved by adding the code snippet above in the buildspec of your pipeline.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ This buildspec builds a Docker image that bundles the Martini Server Runtime wit
 2. **`martini-upload-package.yaml`**
 This buildspec focuses on deploying your Martini packages to an existing Martini Server Runtime instance. This method requires deploying only the packages, keeping the runtime instance unchanged, which is a streamlined option for environments where the runtime remains consistent but packages need frequent updates. 
 
-If you need to migrate from AWS CodeCommit to another Git provider such as GitHub, follow this guide: [How to migrate your AWS CodeCommit repository to another Git provider](https://aws.amazon.com/blogs/devops/how-to-migrate-your-aws-codecommit-repository-to-another-git-provider/).
+## Cloning and Setting Up the Pipeline
+You will need to clone this repository or at least copy the Dockerfile and one or both of the buildspec files, depending on your intended use case. You can configure build triggers in CodePipeline in various ways, with the default being to trigger the pipeline when a code change or push is detected in the source repository.
 
+We provide Terraform templates that create the required AWS resources, streamlining the process of managing your pipeline and infrastructure as code. These templates handle the creation of permissions and setup, ensuring a smooth integration with CodePipeline. You can find the Terraform templates in the following repository: [Martini AWS CodePipeline Terraform Module.](https://github.com/torocloud/martini-aws-codepipeline-terraform-module/tree/main).
+
+If you need to migrate from AWS CodeCommit to another Git provider such as GitHub, follow this guide: 
+[How to migrate your AWS CodeCommit repository to another Git provider](https://aws.amazon.com/blogs/devops/how-to-migrate-your-aws-codecommit-repository-to-another-git-provider/).
 
 ## Environment Variables
 
@@ -27,6 +32,22 @@ The variables listed below are used in the buildspec when configuring your CI/CD
 | `MARTINI_USER_PASSWORD`       | Yes          | The password for authentication with the Martini API.                                                                   |
 | `${PARAMETER_NAME}`           | Yes          | The parameter store parameter name that is being used to fetch environment variables.                                   |
 
+### Setting Up Parameters in AWS Parameter Store
+You need to create a new parameter in AWS Parameter Store and define the required variables along with their values in JSON format.
+
+For `martini-build-image.yaml`, define the following variables:
+`MARTINI_VERSION`, `AWS_REGION`, `AWS_ACCOUNT_ID`, and `ECR_REPO_NAME`.
+
+For `martini-upload-package.yaml`, define:
+`BASE_URL`, `MARTINI_USER_NAME`, and `MARTINI_USER_PASSWORD.`
+
+After setting the parameters, replace `${PARAMETER_NAME}` with the actual parameter name in the following command:
+```bash
+PARAMETER=$(aws ssm get-parameter --name "${PARAMETER_NAME}" --with-decryption --query "Parameter.Value" --output text)
+```
+
+<sub>This command is present in both buildspec files.</sub>
+
 ## Running the Pipeline
 
 By default, a pipeline starts automatically when it is created and any time a change is made in it's source repository. However, you might want to rerun the most recent revision through the pipeline a second time. You can use the CodePipeline console or the AWS CLI and start-pipeline-execution command to manually rerun the most recent revision through your pipeline.
@@ -37,4 +58,4 @@ To start the pipeline execution, use the following command:
 aws codepipeline start-pipeline-execution --name pipeline-name
 ```
 
-You can also use this pipeline as an extension of your pipeline and this can be achieved by adding the code snippet above in the buildspec of your pipeline.
+This command can also be added to the buildspec of your pipeline, enabling automated execution of the pipeline from the most recent revision in its source repository.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+
+# Martini Build Pipeline
+
+This Martini Build Pipeline utilizes AWS CodePipeline. The repository includes two buildspec files for different build processes, such as building Docker images for the Martini runtime and uploading Martini packages. 
+
+If you need to migrate from CodeCommit to another Git provider such as GitHub, follow this guide: [How to migrate your AWS CodeCommit repository to another Git provider](https://aws.amazon.com/blogs/devops/how-to-migrate-your-aws-codecommit-repository-to-another-git-provider/).
+
+
+## Buildspec Files
+
+- **`martini-build-image.yaml`**: Responsible for building and pushing Docker images for the Martini runtime to AWS ECR.
+- **`martini-upload-package.yaml`**: Handles the zipping and uploading of Martini packages to the appropriate API endpoint.
+
+## Getting Started
+
+### Step 1: Choose the Appropriate Buildspec
+
+Determine which buildspec file suits your project's requirements, and ensure it is placed in the root directory of your repository.
+
+### Step 2: Update Environment Variables
+
+Make sure sensitive information like tokens, credentials, and URLs are securely managed by passing them as environment variables during the build process. These should be set in your local environment or CI/CD pipeline configuration.
+
+The necessary variables are stored in AWS Parameter Store, and the buildspec files retrieve them during the pre-build stage.
+
+### Step 3: Execute the Build
+
+Depending on your configuration, you can use the pipeline on its own or extend your own pipeline. To extend your pipeline, you can trigger the pipeline using the AWS CLI:
+
+```bash
+aws codepipeline start-pipeline-execution --name pipeline-name
+```
+
+## Environment Variables
+
+The following environment variables are required for configuring this build process. These variables should be passed as environment variables when running the scripts or configuring your CI/CD pipeline:
+
+| **Variable Name**             | **Required** | **Description**                                                                                                         |
+|-------------------------------|--------------|-------------------------------------------------------------------------------------------------------------------------|
+| `MARTINI_VERSION`             | Yes          | The version of the Martini runtime to be used when building the Docker image.                                           |
+| `AWS_REGION`                  | Yes          | The AWS region where your ECR repository is located.                                                                   |
+| `AWS_ACCOUNT_ID`              | Yes          | The AWS account ID where the ECR repository is hosted.                                                                 |
+| `ECR_REPO_NAME`               | Yes          | The name of the ECR repository where the Docker image will be pushed.                                                  |
+| `BASE_URL`                    | Yes          | The base URL for the API endpoint where packages will be uploaded and requests are made.                                |
+| `MARTINI_USER_NAME`           | Yes          | The username for authentication with the Martini API.                                                                   |
+| `MARTINI_USER_PASSWORD`       | Yes          | The password for authentication with the Martini API.                                                                   |
+| `${PARAMETER_NAME}`           | Yes          | The parameter store parameter name that is being used to fetch environment variables.                                   |
+
+## Input Descriptions
+
+- **`DOCKER_IMAGE_NAME`**:  
+  - Defines the Docker image name and tag in the format `repository:tag` used for building and tagging the image.  
+
+- **`MARTINI_VERSION`**:  
+  - Specifies the version of the Martini runtime included in the Docker image. It's passed as a build argument during the Docker build process.  
+
+- **`BASE_URL`**:  
+  - The remote Martini Runtime Server’s base URL, used for uploading packages.  
+
+- **`MARTINI_USER_NAME`** and **`MARTINI_USER_PASSWORD`**:  
+  - Credentials needed to authenticate with the Martini API, essential for obtaining OAuth tokens and interacting with the API for package uploads.  
+
+- **`${PARAMETER_NAME}`**:  
+  - Refers to the name of the parameter in AWS SSM Parameter Store used to fetch environment variables like `MARTINI_VERSION`, `AWS_REGION`, `AWS_ACCOUNT_ID`, and `ECR_REPO_NAME`.  

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,9 @@
+# Use the toroio/martini-runtime:${MARTINI_VERSION} image as the base
+ARG MARTINI_VERSION
+FROM toroio/martini-runtime:${MARTINI_VERSION}
+
+# Copy packages to the MR image
+COPY packages /data/packages
+
+# Set the working directory
+WORKDIR /data

--- a/martini-build-image.yaml
+++ b/martini-build-image.yaml
@@ -1,0 +1,37 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      # Install necessary dependencies
+
+  pre_build:
+    commands:
+      # Fetch environment variables from Parameter Store
+      - echo "Fetching environment variables from Parameter Store..."
+      - PARAMETER=$(aws ssm get-parameter --name "${PARAMETER_NAME}" --with-decryption --query "Parameter.Value" --output text)
+      - MARTINI_VERSION=$(echo $PARAMETER | jq -r '.MARTINI_VERSION')
+      - AWS_REGION=$(echo $PARAMETER | jq -r '.AWS_REGION')
+      - AWS_ACCOUNT_ID=$(echo $PARAMETER | jq -r '.AWS_ACCOUNT_ID')
+      - ECR_REPO_NAME=$(echo $PARAMETER | jq -r '.ECR_REPO_NAME')
+
+  build:
+    commands:
+      # Build the Docker image
+      - docker build --build-arg MARTINI_VERSION=${MARTINI_VERSION} -t mr:${MARTINI_VERSION} .
+
+      # Authenticate with AWS ECR
+      - aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
+
+      # Tag the Docker image for AWS ECR
+      - docker tag mr:${MARTINI_VERSION} ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO_NAME}:${MARTINI_VERSION}
+
+  post_build:
+    commands:
+      # Push the Docker image to AWS ECR
+      - docker push ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO_NAME}:${MARTINI_VERSION}
+
+artifacts:
+  files:
+    - '**/*'
+  discard-paths: yes

--- a/martini-upload-package.yaml
+++ b/martini-upload-package.yaml
@@ -1,0 +1,59 @@
+version: 0.2
+
+phases:
+  install:
+    commands:
+      # Install dependencies if needed
+      - echo "Installing AWS CLI if not already installed..."
+
+  pre_build:
+    commands:
+      # Fetch parameters from Parameter Store
+      - PARAMETER=$(aws ssm get-parameter --name "martini-upload-packages" --with-decryption --query "Parameter.Value" --output text)
+      - BASE_URL=$(echo $PARAMETER | jq -r '.BASE_URL')
+      - MARTINI_USER_NAME=$(echo $PARAMETER | jq -r '.MARTINI_USER_NAME')
+      - MARTINI_USER_PASSWORD=$(echo $PARAMETER | jq -r '.MARTINI_USER_PASSWORD')
+
+      # Fetch OAuth token
+      - echo "Fetching the OAuth token..."
+      - |
+        GET_TOKEN=$(curl --location "${BASE_URL}/oauth/token" \
+          --header "Content-Type: application/x-www-form-urlencoded" \
+          --data-urlencode "grant_type=password" \
+          --data-urlencode "client_id=TOROMartini" \
+          --data-urlencode "client_secret=TOROMartini" \
+          --data-urlencode "username=${MARTINI_USER_NAME}" \
+          --data-urlencode "password=${MARTINI_USER_PASSWORD}")
+      - token=$(echo $GET_TOKEN | jq -r '.access_token')
+
+  build:
+    commands:
+      # Prepare staging folder
+      - cd packages
+      - for dir in */; do dir=${dir%*/}; zip -r "../${dir}.zip" "$dir"; done
+      - cd ..
+
+      # Upload zip files to the endpoint
+      - |
+        for zipfile in *.zip; do
+          echo "Uploading $zipfile"
+          curl -X POST "${BASE_URL}/esbapi/packages/upload?stateOnCreate=STARTED&replaceExisting=true" \
+            -H "accept: application/json" \
+            -H "Content-Type: multipart/form-data" \
+            -F "file=@\"${zipfile}\";type=application/x-zip-compressed" \
+            -H "Authorization: Bearer ${token}"
+        done
+
+  post_build:
+    commands:
+      # Test the API with a custom greeting request
+      - |
+        API_RESPONSE=$(curl -s "${BASE_URL}/api/greeting?name=Neo" \
+          -H "Authorization: Bearer ${token}")
+      - echo "Response from the API request:"
+      - echo "$API_RESPONSE"
+
+artifacts:
+  files:
+    - '**/*'
+  discard-paths: yes


### PR DESCRIPTION
Intro
This sentence and other references to the same need further clarification:
"such as building Docker images for the Martini runtime and uploading Martini packages"

There are two choices:
1. Build a Docker image that is bundled with a Martini Server Runtime image and your Martini Packages. This option means that you can maintain control over both the version of the runtime and your packages in a single deployment.
2. Deploy your Packages to an existing Martini Server Runtime instance.

Buildspec files:
as above
- I've updated [the intro and build options](https://github.com/torocloud/martini-build-pipeline-aws-codepipeline/tree/development?tab=readme-ov-file#build-options) of the README file with

Step 2
"Make sure sensitive information like tokens, credentials, and URLs are securely managed by passing them as environment variables during the build process. "
Which environmental variables are you referring to?
- Its the variables specified in the [table.](evelopment?tab=readme-ov-file#environment-variables) These variables used in the buildspec files are stored in AWS Parameter Store, rather than in GitHub. These environment variables are configured this way to prevent being exposed during the build process in the build inputs.


Step 3
"Execute the build"
How?

"To extend your pipeline, you can trigger the pipeline using the AWS CLI:"
"aws codepipeline start-pipeline-execution --name pipeline-name"
How does this extend their pipeline?
- Its the same on how you run the pipeline from AWS console and CLI. [To run the pipeline](https://github.com/torocloud/martini-build-pipeline-aws-codepipeline/tree/development?tab=readme-ov-file#running-the-pipeline), you just need to add this command in your buildspec file `aws codepipeline start-pipeline-execution --name pipeline-name`


Environmental Variables
"Variable Name Required"
"MARTINI_VERSION Yes"
This should be configured so that if null LATEST is used, else support a value of LATEST
- I've add that part for the `MARTINI_VERSION` description

Input Descriptions
These seem to be a duplicate of the table
- I've omitted this part